### PR TITLE
Added missing period.

### DIFF
--- a/careers:ios.html
+++ b/careers:ios.html
@@ -120,7 +120,7 @@
         <h2><strong>iOS Developer at Livefront</strong></h2>
         <p>We are a tight-knit, talented group of engineers and designers building custom mobile apps for smart clients. We have an incredible attention to detail and very high standards–if you want to join our team, you'll need to demonstrate that you do
           too.</p>
-        <p>Your primary role will be development of mobile applications for the iOS platform. Bonus if you can rock C#, Java or Ruby. You have an innate, built-in, almost scary penchant for programming You communicate clearly. You have a proven track record
+        <p>Your primary role will be development of mobile applications for the iOS platform. Bonus if you can rock C#, Java or Ruby. You have an innate, built-in, almost scary penchant for programming. You communicate clearly. You have a proven track record
           of self-motivation. You're active in the tech community. You never tire of Chipotle.</p>
         <h3>About our team</h3>
         <p>Our team was founded on the principles of craftsmanship and simplicity. We are a group of expert designers and developers you can believe in.</p>


### PR DESCRIPTION
The period is actually missing at http://livefront.com/careers/ios/ as well.